### PR TITLE
Feature Detect All Parent Branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # hg-auto-semver
-Automatically bump versions according to parent branch name.
+Automatically bump versions according to parents branch name.
 
-# How it works
-hg-auto-semver checks for the parent branch name after a merge.
-- If the branch contains `breaking-feature-` it'll bump the MAJOR version.
-- If the branch contains `feature-`, it'll bump the MINOR version.
+## How it works
+hg-auto-semver checks for the merged branches between the current revision and the latest tag.
+- If a branch contains `breaking-feature-` it'll bump the MAJOR version.
+- Otherwise, if a branch contains `feature-`, it'll bump the MINOR version.
 - Otherwise it will bump a PATCH version.
 
-# Usage
+Note: If no tag exists on the current branch it will use the latest merged branch to bump the version
+
+## Usage
 
 ```
-npm install hg-auto-semver --save
+npm install coveo-hg-auto-semver --save
 ```
 
 To your package.json add

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,8 +16,10 @@ function getParentBranches() {
 
     let branches = [];
     if (lastestTag) {
+        // Get all parent branches of commits between current revision and latest tag
         branches = execSync(`hg log -r "parents(ancestor(${lastestTag}, ${currentRev})::${currentRev} - ancestor(${lastestTag}, ${currentRev}))" --template "{branch} "`).toString().trim().split(' ');
     } else {
+        // Get the parent branch of the current commit
         branches = [execSync('hg log --rev "p2(.)" --template "{branch}"').toString().trim()];
     }
     // remove empty branch and duplicates
@@ -41,6 +43,7 @@ try {
     const branches = getParentBranches();
     let toBump = Version.PATCH;
 
+    // Loop on detected branches to bump according to the biggest change
     branches.forEach(branch => {
         if (breakingFeatureRegex.test(branch)) {
             toBump = Version.MAJOR;


### PR DESCRIPTION
Instead of basing our bump on the latest change detect all the branches
since the last tag