### PR TITLE
Accept one argument to specifically bump a type of version

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -106,7 +106,7 @@ try {
         case Version.MINOR:
         case Version.MAJOR:
             hasArg = true;
-            toBump = process.argv[2];
+            toBump = arg;
             console.log(`Bumping a ${toBump} version as specified`);
             break;
         default:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -105,7 +105,6 @@ try {
         case Version.PATCH:
         case Version.MINOR:
         case Version.MAJOR:
-            hasArg = true;
             toBump = arg;
             console.log(`Bumping a ${toBump} version as specified`);
             break;


### PR DESCRIPTION
Useful to take advantage of the looping on published versions