### PR TITLE
Set the package.json version to the latest tag

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,7 +39,7 @@ function getParentRevision() {
 
 // Removes the "v" at the begining of the current version;
 function getCleanVersion() {
-    return execSync(`hg log -r "." --template "{latesttag}"`).toString().trim().substr(1);
+    return execSync(`hg log -r "." --template "{latesttag}"`).toString().trim().replace(/^v/, '');
 }
 
 function getPackageJSONProperty(property) {


### PR DESCRIPTION
We want to be able to commit without the version inside the package.json file. This change will make sure we start from the current version before bumping a new one.