### PR TITLE
Fix get parent revision

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,7 +38,7 @@ function getLatestTag() {
 
 function getParentRevision() {
     const currentBranch = getCurrentBranch();
-    return execSync(`hg log --rev "parents(.)" --template "{rev}" -b ${currentBranch} `);
+    return execSync(`hg log --rev "parents(.)" --template "{rev}" -b ${currentBranch}`).toString().trim();
 }
 
 function getParentBranches() {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,7 +37,8 @@ function getLatestTag() {
 }
 
 function getParentRevision() {
-    return execSync(`hg log --rev "parents(.)" --template "{rev}" `);
+    const currentBranch = getCurrentBranch();
+    return execSync(`hg log --rev "parents(.)" --template "{rev}" -b ${currentBranch} `);
 }
 
 function getParentBranches() {


### PR DESCRIPTION
Fix get parent revision to get the current branch parent when the current revision is a merge.